### PR TITLE
Feat#5 : 방명록 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 //	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation group: 'org.webjars', name: 'stomp-websocket', version: '2.3.3-1'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/Be9room/festime/config/WebSocketConfigurer.java
+++ b/src/main/java/Be9room/festime/config/WebSocketConfigurer.java
@@ -1,33 +1,32 @@
-package submeet.backend.config;
+package Be9room.festime.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
-import submeet.backend.handler.StompHandler;
 
 @Configuration
 @EnableWebSocketMessageBroker
 @RequiredArgsConstructor
 public class WebSocketConfigurer implements WebSocketMessageBrokerConfigurer {
-    private final StompHandler stompHandler;
+//    private final StompHandler stompHandler;
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/stomp/chat")
+        registry.addEndpoint("/stomp/guestbook")
                 .setAllowedOrigins("*");
 //                .withSockJS();
-        //주소 : ws://localhost:8080/stomp/chat
+        //주소 : ws://localhost:8080/stomp/guestbook
     }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.setPathMatcher(new AntPathMatcher("."));
+//        registry.setPathMatcher(new AntPathMatcher("."));
         registry.setApplicationDestinationPrefixes("/pub");
-        registry.enableStompBrokerRelay("/queue", "/topic", "/exchange", "/amq/queue");
+//        registry.enableStompBrokerRelay("/queue", "/topic", "/exchange", "/amq/queue");
+        registry.enableSimpleBroker("/sub");
     }
 
 //    @Override

--- a/src/main/java/Be9room/festime/config/WebSocketConfigurer.java
+++ b/src/main/java/Be9room/festime/config/WebSocketConfigurer.java
@@ -1,0 +1,37 @@
+package submeet.backend.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import submeet.backend.handler.StompHandler;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfigurer implements WebSocketMessageBrokerConfigurer {
+    private final StompHandler stompHandler;
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/stomp/chat")
+                .setAllowedOrigins("*");
+//                .withSockJS();
+        //주소 : ws://localhost:8080/stomp/chat
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.setPathMatcher(new AntPathMatcher("."));
+        registry.setApplicationDestinationPrefixes("/pub");
+        registry.enableStompBrokerRelay("/queue", "/topic", "/exchange", "/amq/queue");
+    }
+
+//    @Override
+//    public void configureClientInboundChannel(ChannelRegistration registration) {
+//        registration.interceptors(stompHandler);
+//    }
+}

--- a/src/main/java/Be9room/festime/controller/MessageController.java
+++ b/src/main/java/Be9room/festime/controller/MessageController.java
@@ -1,0 +1,2 @@
+package Be9room.festime.controller;public class MessageController {
+}

--- a/src/main/java/Be9room/festime/controller/MessageController.java
+++ b/src/main/java/Be9room/festime/controller/MessageController.java
@@ -1,2 +1,61 @@
-package Be9room.festime.controller;public class MessageController {
+package Be9room.festime.controller;
+
+import Be9room.festime.dto.MessageDTO;
+import Be9room.festime.enums.MessageType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class MessageController {
+    private final SimpMessagingTemplate template;
+    /**
+     * 채팅 입장
+     * /pub/chat/enter 로 보내면 여기로 온다.
+     * @param message
+     */
+    @MessageMapping(value = "/guestbook/enter")
+    public void enter(MessageDTO message){
+        log.info("eee");
+        message.setMessageType(MessageType.ENTER.toString());
+        message.setMessage(message.getMemberName() + "님이 방명록에 참여했어요!");
+
+        /* 메세지 저장 부분 */
+
+        template.convertAndSend("/sub/guestbook", message);
+    }
+
+    /**
+     * 메세지 전송
+     * @param message
+     */
+    @MessageMapping(value = "/guestbook/message")
+    public void message(MessageDTO message){
+        log.info("messsaggee");
+        message.setMessageType(MessageType.MESSAGE.toString());
+
+        /* 메세지 저장 부분 */
+
+        template.convertAndSend("/sub/guestbook", message);
+    }
+
+    /**
+     * 채팅방 나감
+     * @param message
+     */
+    @MessageMapping(value = "/guestbook/leave")
+    public void leave(MessageDTO message){
+        message.setMessageType(MessageType.LEAVE.toString());
+        message.setMessage(message.getMemberName() + "님이 방명록에서 나가셨어요!");
+
+        /* 메세지 저장 부분 */
+
+        template.convertAndSend("/sub/guestbook",  message);
+    }
+
+
 }

--- a/src/main/java/Be9room/festime/dto/MessageDTO.java
+++ b/src/main/java/Be9room/festime/dto/MessageDTO.java
@@ -1,0 +1,2 @@
+package Be9room.festime.dto;public class MessageDTO {
+}

--- a/src/main/java/Be9room/festime/dto/MessageDTO.java
+++ b/src/main/java/Be9room/festime/dto/MessageDTO.java
@@ -1,2 +1,15 @@
-package Be9room.festime.dto;public class MessageDTO {
+package Be9room.festime.dto;
+
+import lombok.*;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class MessageDTO {
+    private String memberName;
+    private String memberId;
+    private String messageType;
+    private String message;
 }

--- a/src/main/java/Be9room/festime/enums/MessageType.java
+++ b/src/main/java/Be9room/festime/enums/MessageType.java
@@ -1,2 +1,5 @@
-package Be9room.festime.enums;public enum MessageType {
+package Be9room.festime.enums;
+
+public enum MessageType {
+    ENTER, LEAVE, MESSAGE
 }

--- a/src/main/java/Be9room/festime/enums/MessageType.java
+++ b/src/main/java/Be9room/festime/enums/MessageType.java
@@ -1,0 +1,2 @@
+package Be9room.festime.enums;public enum MessageType {
+}


### PR DESCRIPTION
## 이슈번호 : #5 
- 방명록 기능 구현
- STOMP 기반으로 구현
- 일단은 메세지 큐잉 서버를 따로 두지 않고 메모리 상에서 메세지 주고 받을 수 있게 구현

## 연결하기
> 연결 URL : wss://api.festime.submeet.shop/stomp/guestbook

## 구독하기
> STOMP subscribe destination : /sub/guestbook

## 방명록에 입장
> - STOMP send Destination : /pub/guestbook/enter 
> - Message Content : 아래와 같은 json 형식
> ```json
> {   "memberName": "졸린인덕이",   "memberId" : "uuid"  } 
> ```
> 전달하면 아래 사진과 같이 /sub/guestbook 을 구독한 모든 사용자들에게 방명록 입장했다는 메세지 나옴
>  ![image](https://github.com/user-attachments/assets/83897bb1-bcca-4e9f-b8ae-d590001d4b7d)
## 방명록에 메세지 보내기
> - STOMP send Destination : /pub/guestbook/message 
> - Message Content : 아래의 json과 같은 형식
>```json
>{   "memberName": "졸린인덕이",   "memberId" : "uuid",   "message": "안녕하세요" } 
>```
> 전달하면 아래 사진과 같이 /sub/guestbook 을 구독한 모든 사용자들에게 메세지 보냄
>  ![image](https://github.com/user-attachments/assets/051f1443-f702-450f-8093-f58c22ca1f47)

## 방명록 떠나기
> - STOMP send Destination : /pub/guestbook/leave
> - Message Content : 아래의 json과 같은 형식
>```json
>{   "memberName": "졸린인덕이",   "memberId" : "uuid"} 
>```
> 전달하면 아래 사진과 같이 /sub/guestbook 을 구독한 모든 사용자들에게 방명록을 떠났다는 메세지 나옴
> ![image](https://github.com/user-attachments/assets/d7b5e437-8ce5-4604-ab11-477bad9bf4fa)
